### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides Claude with access to Microsoft Outlook through the Microsoft Graph API. Features multi-account support, remote deployment capabilities, and comprehensive email, calendar, and folder management.
 
+<a href="https://glama.ai/mcp/servers/@johnsonboibeats/Outlook-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@johnsonboibeats/Outlook-MCP/badge" alt="Outlook Server MCP server" />
+</a>
+
 ## Quick Start
 
 ### 1. Install Dependencies


### PR DESCRIPTION
This PR adds a badge for the [Outlook MCP Server](https://glama.ai/mcp/servers/@johnsonboibeats/Outlook-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@johnsonboibeats/Outlook-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@johnsonboibeats/Outlook-MCP/badge" alt="Outlook Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.